### PR TITLE
feat(): Lock hummingbot version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - libcxx
   - pip
   - pip:
-      - hummingbot
+      - hummingbot==20250220
       - numpy==1.26.4
       - plotly
       - pycoingecko


### PR DESCRIPTION
The newest `hummingbot` version is breaking the `make install` command and not all dependencies can be installed anymore.

```
make install
conda env create -f environment.yml
/home/pascal/anaconda3/lib/python3.11/site-packages/conda/base/context.py:198: FutureWarning: Adding 'defaults' to channel list implicitly is deprecated and will be removed in 25.9.

To remove this warning, please choose a default channel explicitly with conda's regular configuration system, e.g. by adding 'defaults' to the list of channels:

  conda config --add channels defaults

For more information see https://docs.conda.io/projects/conda/en/stable/user-guide/configuration/use-condarc.html

  deprecated.topic(
Channels:
 - defaults
 - conda-forge
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: done

Downloading and Extracting Packages:

Preparing transaction: done
Verifying transaction: done
Executing transaction: done
Installing pip dependencies: | Ran pip subprocess with arguments:
['/home/pascal/anaconda3/envs/quants-lab/bin/python', '-m', 'pip', 'install', '-U', '-r', '/home/pascal/src/tmp/quants-lab/condaenv.15n277yh.requirements.txt', '--exists-action=b']
Pip subprocess output:
Collecting hummingbot (from -r /home/pascal/src/tmp/quants-lab/condaenv.15n277yh.requirements.txt (line 1))
  Using cached hummingbot-20250303.tar.gz (6.0 MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'

Pip subprocess error:
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [25 lines of output]
      Warning: passing language='c++' to cythonize() is deprecated. Instead, put "# distutils: language=c++" in your .pyx or .pxd file(s)
      Traceback (most recent call last):
        File "/home/pascal/anaconda3/envs/quants-lab/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/home/pascal/anaconda3/envs/quants-lab/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
        File "/home/pascal/anaconda3/envs/quants-lab/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-x5z6ffy8/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 334, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
        File "/tmp/pip-build-env-x5z6ffy8/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 304, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-x5z6ffy8/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 522, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-x5z6ffy8/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 320, in run_setup
          exec(code, locals())
        File "<string>", line 141, in <module>
        File "<string>", line 129, in main
        File "/tmp/pip-build-env-x5z6ffy8/overlay/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 979, in cythonize
          module_list, module_metadata = create_extension_list(
        File "/tmp/pip-build-env-x5z6ffy8/overlay/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 821, in create_extension_list
          for file in nonempty(sorted(extended_iglob(filepattern)), "'%s' doesn't match any files" % filepattern):
        File "/tmp/pip-build-env-x5z6ffy8/overlay/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 116, in nonempty
          raise ValueError(error_msg)
      ValueError: 'hummingbot/**/*.pyx' doesn't match any files
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.

failed

CondaEnvException: Pip failed

make: *** [Makefile:10: install] Error 1
```