### PR TITLE
fix: add Mongo Express UI to docker-compose-db.yml

### DIFF
--- a/docker-compose-db.yml
+++ b/docker-compose-db.yml
@@ -11,5 +11,22 @@ services:
     volumes:
       - mongodb_data_ql:/data/db
     restart: unless-stopped
+
+  mongo-express:
+    image: mongo-express:latest
+    container_name: mongo-express
+    environment:
+      ME_CONFIG_MONGODB_SERVER: mongodb
+      ME_CONFIG_MONGODB_PORT: 27017
+      ME_CONFIG_MONGODB_ADMINUSERNAME: admin
+      ME_CONFIG_MONGODB_ADMINPASSWORD: admin
+      ME_CONFIG_BASICAUTH_USERNAME: admin
+      ME_CONFIG_BASICAUTH_PASSWORD: changeme
+    ports:
+      - "28081:8081"
+    depends_on:
+      - mongodb
+    restart: unless-stopped
+
 volumes:
   mongodb_data_ql:


### PR DESCRIPTION
- Add mongo-express service to enable MongoDB web interface
- Configure service to run on port 28081 as documented in install.sh
- Set up authentication with admin/changeme credentials as referenced in installation script
- Add proper dependency on mongodb service
- Resolves issue where http://localhost:28081/ was not accessible after running make run-db

This addresses the discrepancy between the installation documentation mentioning MongoDB UI availability at localhost:28081 and the actual docker-compose configuration.